### PR TITLE
feat: Add Japanese double pinyin input method

### DIFF
--- a/Rime/default.custom.yaml
+++ b/Rime/default.custom.yaml
@@ -1,4 +1,5 @@
 patch:
   schema_list:
     - schema: sno_jpn_wubi86_eng
+    - schema: japanese_doublepinyin
   style/vxertical_text_with_wrap: false           # 文本竖排模式下，自动换行：true；false

--- a/Rime/japanese_doublepinyin.schema.yaml
+++ b/Rime/japanese_doublepinyin.schema.yaml
@@ -1,0 +1,145 @@
+# Rime schema
+# encoding: utf-8
+
+schema:
+  schema_id: japanese_doublepinyin
+  name: 朙月双拼和字
+  version: "0.1"
+  author:
+    - 佛振 <chen.sst@gmail.com>
+    - Snowstar Miao <snomiao@gmail.com>
+  description: |
+    Rime 双拼輸入方案（小鹤双拼）用于日文输入。
+    基于 japanese_pinyin 方案修改。
+    参考以下作品而创作：
+      * CC-CEDICT
+      * Android open source project
+      * Chewing - 新酷音
+      * opencc - 开放中文转换
+      * 小鹤双拼
+  dependencies:
+    - stroke
+
+switches:
+  - name: ascii_mode
+    states: [中文, 西文]
+    reset: 0
+  - name: full_shape
+    states: [半角, 全角]
+  - name: ascii_punct
+    states: [。，, ．，]
+
+engine:
+  processors:
+    - ascii_composer
+    - recognizer
+    - key_binder
+    - speller
+    - punctuator
+    - selector
+    - navigator
+    - express_editor
+  segmentors:
+    - ascii_segmentor
+    - matcher
+    - abc_segmentor
+    - punct_segmentor
+    - fallback_segmentor
+  translators:
+    - punct_translator
+    - table_translator@custom_phrase
+    - reverse_lookup_translator
+    - script_translator
+  filters:
+    - simplifier@simplifier_t2jp
+    - uniquifier
+
+################## simplifier
+
+simplifier_t2jp:
+  opencc_config: t2jp.json
+  tips: none
+
+####################### speller
+speller:
+  alphabet: zyxwvutsrqponmlkjihgfedcba
+  delimiter: " '"
+  algebra:
+    - erase/^xx$/
+    - derive/^([jqxy])u$/$1v/
+    # 零声母音节
+    - derive/^([aoe])([ioun])$/$1$1$2/
+    - xform/^([aoe])(ng)?$/$1$1$2/
+    # 双拼编码规则（小鹤双拼）
+    - xform/iu$/Q/
+    - xform/(.)ei$/$1W/
+    - xform/uan$/R/
+    - xform/[uv]e$/T/
+    - xform/un$/Y/
+    - xform/^sh/U/
+    - xform/^ch/I/
+    - xform/^zh/V/
+    - xform/uo$/O/
+    - xform/ie$/P/
+    - xform/i?ong$/S/
+    - xform/ing$|uai$/K/
+    - xform/(.)ai$/$1D/
+    - xform/(.)en$/$1F/
+    - xform/(.)eng$/$1G/
+    - xform/[iu]ang$/L/
+    - xform/(.)ang$/$1H/
+    - xform/ian$/M/
+    - xform/(.)an$/$1J/
+    - xform/(.)ou$/$1Z/
+    - xform/[iu]a$/X/
+    - xform/iao$/N/
+    - xform/(.)ao$/$1C/
+    - xform/ui$/V/
+    - xform/in$/B/
+    # 转换为小写
+    - xlit/QWRTYUIOPSDFGHJKLZXCVBNM/qwrtyuiopsdfghjklzxcvbnm/
+    # 简拼支持
+    - abbrev/^([a-z]).+$/$1/
+    - abbrev/^([zcs]h).+$/$1/
+
+########## Translator
+translator:
+  dictionary: japanese_pinyin
+  preedit_format:
+    - xform/([nl])v/$1ü/
+    - xform/([nl])ue/$1üe/
+    - xform/([jqxy])v/$1u/
+
+# custom...
+custom_phrase:
+  dictionary: ""
+  user_dict: custom_phrase
+  db_class: stabledb
+  enable_completion: false
+  enable_sentence: false
+  initial_quality: 1
+
+### Reverse
+
+reverse_lookup:
+  dictionary: stroke
+  enable_completion: true
+  prefix: "`"
+  suffix: "'"
+  tips: 〔筆畫〕
+  preedit_format:
+    - xlit/hspnz/一丨丿丶乙/
+  comment_format:
+    - xform/([nl])v/$1ü/
+
+punctuator:
+  import_preset: symbols
+
+key_binder:
+  import_preset: default
+
+recognizer:
+  import_preset: default
+  patterns:
+    punct: "^/([0-9]0?|[A-Za-z]+)$"
+    reverse_lookup: "`[a-z]*'?$"

--- a/docs/japanese-doublepinyin.md
+++ b/docs/japanese-doublepinyin.md
@@ -1,0 +1,87 @@
+# 日语双拼输入法 (Japanese Double Pinyin Input Method)
+
+## 简介 (Introduction)
+
+`japanese_doublepinyin` 是基于小鹤双拼方案的日语输入法，允许用户使用双拼编码输入日语汉字和词汇。
+
+## 功能特性 (Features)
+
+- 基于小鹤双拼编码方案
+- 支持日语汉字输入
+- 支持简拼
+- 自动繁体转日文汉字
+- 笔画反查功能
+
+## 使用方法 (Usage)
+
+### 启用输入法 (Enable Input Method)
+
+1. 将 `japanese_doublepinyin.schema.yaml` 放入 Rime 用户文件夹
+2. 重新部署 Rime
+3. 按 `F4` 或 `Ctrl+`` 选择 "朙月双拼和字"
+
+### 双拼编码规则 (Double Pinyin Encoding Rules)
+
+本方案使用小鹤双拼编码：
+
+#### 韵母编码 (Finals)
+- `iu` → `q`
+- `ei` → `w`
+- `uan` → `r`
+- `ue/ve` → `t`
+- `un` → `y`
+- `uo` → `o`
+- `ie` → `p`
+- `ong/iong` → `s`
+- `ing/uai` → `k`
+- `ai` → `d`
+- `en` → `f`
+- `eng` → `g`
+- `iang/uang` → `l`
+- `ang` → `h`
+- `ian` → `m`
+- `an` → `j`
+- `ou` → `z`
+- `ia/ua` → `x`
+- `iao` → `n`
+- `ao` → `c`
+- `ui` → `v`
+- `in` → `b`
+
+#### 声母编码 (Initials)
+- `sh` → `u`
+- `ch` → `i`
+- `zh` → `v`
+
+#### 零声母 (Zero Initial)
+- 零声母音节需要双击韵母首字母，例如：
+  - `an` → `aj`
+  - `ang` → `ah`
+  - `ao` → `ac`
+  - `ai` → `ad`
+
+## 示例 (Examples)
+
+### 输入示例
+- 中国 `vggo` (zh→v, ong→s, gu→go, o→o)
+- 学习 `xtxp` (x, ue→t, x, i→p)
+- 知识 `viui` (zh→v, i, sh→u, i)
+
+## 反查功能 (Reverse Lookup)
+
+按 `` ` `` 键启用笔画反查，支持以下笔画：
+- `h` 一（横）
+- `s` 丨（竖）
+- `p` 丿（撇）
+- `n` 丶（捺）
+- `z` 乙（折）
+
+## 相关文件 (Related Files)
+
+- `japanese_doublepinyin.schema.yaml` - 输入法方案配置
+- `japanese_pinyin.dict.yaml` - 词库文件（共用全拼词库）
+
+## 参考 (References)
+
+- [小鹤双拼官网](https://flypy.com/)
+- [Rime 双拼输入方案](https://github.com/rime/rime-double-pinyin)


### PR DESCRIPTION
## Summary

This PR adds support for double pinyin (双拼) input method for Japanese, addressing issue #13.

## Changes

- ✨ Added `japanese_doublepinyin.schema.yaml` - New input method schema using Xiaohe double pinyin encoding
- 📝 Added documentation in `docs/japanese-doublepinyin.md` explaining usage and encoding rules
- ⚙️ Updated `Rime/default.custom.yaml` to include the new input method in the schema list

## Implementation Details

The implementation uses the popular **Xiaohe (小鹤) double pinyin** encoding scheme, which maps:
- Finals (韵母) to single keys (e.g., `iu→q`, `ei→w`, `uan→r`)
- Initials (声母) like `sh→u`, `ch→i`, `zh→v`
- Zero initials require doubling the first letter of the final

This allows users to input Japanese characters using only 2 keystrokes per syllable instead of full pinyin.

## Usage Example

After deploying:
1. Press `F4` or `Ctrl+`` to switch input methods
2. Select "朙月双拼和字"
3. Type using double pinyin encoding

Example inputs:
- 中国: `vggo` (zh→v, ong→s becomes go, gu→go, o→o)
- 学习: `xtxp` (x, ue→t, x, i→p)

## Testing Checklist

- [x] Schema file created with proper syntax
- [x] Configuration added to default.custom.yaml
- [x] Documentation written
- [ ] Tested input method deployment (requires Rime installation)
- [ ] Verified double pinyin encoding works correctly

## Related Issues

Closes #13

🤖 Generated with [Claude Code](https://claude.com/claude-code)